### PR TITLE
decouple persistent storage and stateful sets

### DIFF
--- a/.solutions/postgres.yml
+++ b/.solutions/postgres.yml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: postgresdb 
+  name: postgresdb
 spec:
   replicas: 1
   selector:
@@ -11,10 +11,8 @@ spec:
     metadata:
       labels:
         app: postgresdb
+        tier: database
     spec:
-      volumes:
-        - name: data
-          emptyDir: {}
       containers:
        - image: postgres
          name: postgresdb
@@ -33,10 +31,4 @@ spec:
            valueFrom:
              configMapKeyRef:
                name: postgres-config
-               key: postgres.db.name 
-         ports:
-         - containerPort: 5432
-           name: postgresdb
-         volumeMounts:
-           - name: data
-             mountPath: /var/lib/postgresql/data
+               key: postgres.db.name

--- a/postgres-pvc.yml
+++ b/postgres-pvc.yml
@@ -4,8 +4,8 @@ metadata:
   name: postgres-data-db 
 spec:
   accessModes:
-  - ReadWriteOnce
-  storageClassName: default 
+    - ReadWriteOnce
+  storageClassName: default
   resources:
     requests:
-      storage: 16Mi
+      storage: 1Gi

--- a/postgres.yml
+++ b/postgres.yml
@@ -1,11 +1,9 @@
 apiVersion: apps/v1
 kind: ------
 metadata:
-  name: postgresdb 
-  namespace: ------
+  name: postgresdb
 spec:
-  serviceName: postgresdb
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
       app: postgresdb
@@ -13,11 +11,8 @@ spec:
     metadata:
       labels:
         app: postgresdb
+        tier: database
     spec:
-      volumes:
-        - name: data-db
-          persistentVolumeClaim:
-           claimName: postgres-data-db  
       containers:
        - image: ------
          name: postgresdb
@@ -36,10 +31,4 @@ spec:
            valueFrom:
              configMapKeyRef:
                name: postgres-config
-               key: postgres.db.name 
-         ports:
-         - containerPort: ------
-           name: postgresdb
-         volumeMounts:
-           - name: data-db
-             mountPath: /data/db
+               key: postgres.db.name


### PR DESCRIPTION
This commit accompanies the corresponding commit in the
cloudacademy/excercises repository, keeping them consistent.