### PR TITLE
add simple app stressing endpoint to allow demonstrating HPA

### DIFF
--- a/todoui/src/main/java/io/novatec/todoui/TodouiApplication.java
+++ b/todoui/src/main/java/io/novatec/todoui/TodouiApplication.java
@@ -37,6 +37,19 @@ public class TodouiApplication {
 
 	}
 
+	@GetMapping("/stress")
+	public String stress(){
+
+		System.out.println(java.time.LocalDateTime.now() + " : Starting stress");
+                double result = 0;
+                for (int i = 0; i < 100000000; i++) {
+                        result += System.currentTimeMillis();
+                }
+		System.out.println(java.time.LocalDateTime.now() + " : Ending stress, result: " + result);
+		return "redirect:/";
+
+	}
+
 	@PostMapping
 	public String addItem(String toDo){
 


### PR DESCRIPTION
By calling "/stress" the ToDoUI will be kept busy for a while, generating load in the process, before eventually showing the "/" endpoint.

This is thought to be used for demonstrating Kubernetes horizontal pod autoscaling (HPA).